### PR TITLE
Update template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -29,7 +29,7 @@ Resources:
         - EventProcessorExecutionRole
         - Arn
       Timeout: 10
-      Runtime: nodejs6.10
+      Runtime: nodejs6.14
       CodeUri:
         Bucket: !Ref LambdaS3Bucket
         Key: !Ref LambdaDDBEventProcessorS3Key


### PR DESCRIPTION
nodejs6.10 is no longer supported. Changing it to nodejs6.14

*Issue #, if available:*
Issue # 9
*Description of changes:*
Stack creation is getting failed due to unsupported nodejs6.10 version. Changed it to nodejs6.14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
