### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -29,7 +29,7 @@ Resources:
         - EventProcessorExecutionRole
         - Arn
       Timeout: 10
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri:
         Bucket: !Ref LambdaS3Bucket
         Key: !Ref LambdaDDBEventProcessorS3Key


### PR DESCRIPTION
CloudFormation templates in lambda-refarch-streamprocessing have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.